### PR TITLE
Improve admin look

### DIFF
--- a/Mazzaly_backend/urls.py
+++ b/Mazzaly_backend/urls.py
@@ -1,5 +1,9 @@
 from django.contrib import admin
 from django.urls import path, include
+
+admin.site.site_header = "Mazzaly Administration"
+admin.site.site_title = "Mazzaly Admin Portal"
+admin.site.index_title = "Welcome to Mazzaly Dashboard"
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ This is a Django REST API for managing recipes, meal plans and user accounts wit
 
 Environment variables can be configured using a `.env` file. See `.env.example` for the available keys.
 
+## Admin Panel
+
+The project includes a customized Django admin interface with a cleaner
+appearance. To access the admin panel, create a superuser and run the server as
+described above. Navigate to `http://localhost:8000/admin/` and log in with your
+credentials. The admin header and dashboard titles show **Mazzaly Admin** and a
+few style tweaks are applied via `account/static/account/css/admin_custom.css`.
+

--- a/account/static/account/css/admin_custom.css
+++ b/account/static/account/css/admin_custom.css
@@ -1,0 +1,14 @@
+/* Custom styles for Mazzaly admin */
+body {
+    background-color: #f8f9fa;
+}
+#header {
+    background-color: #343a40;
+}
+#header h1 a:link,
+#header h1 a:visited {
+    color: #ffffff;
+}
+#content-main th {
+    background-color: #dee2e6;
+}

--- a/account/templates/admin/base_site.html
+++ b/account/templates/admin/base_site.html
@@ -1,0 +1,11 @@
+{% extends "admin/base.html" %}
+{% load static %}
+{% block title %}{% if title %}{{ title }} | {% endif %}Mazzaly Admin{% endblock %}
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static 'account/css/admin_custom.css' %}">
+{% endblock %}
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">Mazzaly Admin</a></h1>
+{% endblock %}
+{% block nav-global %}{% endblock %}


### PR DESCRIPTION
## Summary
- tweak admin site titles
- add custom base_site template and CSS overrides
- document admin use in README

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

