### PR TITLE
Add recipe card visit tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Charts are rendered with Chart.js and include:
 - **Views per Day** – line chart showing the last week
 - **Verification Status** – doughnut chart of verified vs unverified users
 - **New Recipes** – bar chart of recipes added in the last 30 days
+- **Recipe Card Visits** – line and bar charts of unique visitors over the last
+  24 hours, 7 days and 30 days
 Tables for user activity and total recipe views are paginated 20 rows per page.
 Clicking "Download Monthly PDF" first asks for the month you want to report on
 and then generates the PDF using WeasyPrint.

--- a/analytics/migrations/0002_recipecardvisit.py
+++ b/analytics/migrations/0002_recipecardvisit.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analytics', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RecipeCardVisit',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('ip_address', models.GenericIPAddressField()),
+                ('user_agent', models.CharField(max_length=256)),
+                ('period_start', models.DateTimeField()),
+                ('period_type', models.CharField(max_length=4, choices=[('hour', 'Hour'), ('day', 'Day')])),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                'unique_together': {('ip_address', 'user_agent', 'period_start', 'period_type')},
+            },
+        ),
+    ]

--- a/analytics/migrations/0003_sitevisit_date.py
+++ b/analytics/migrations/0003_sitevisit_date.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analytics', '0002_recipecardvisit'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteVisit',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('date', models.DateField(auto_now_add=True)),
+                ('ip_address', models.GenericIPAddressField()),
+            ],
+            options={'ordering': ['-date']},
+        ),
+    ]

--- a/analytics/migrations/0004_alter_sitevisit_date.py
+++ b/analytics/migrations/0004_alter_sitevisit_date.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analytics', '0003_sitevisit_date'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='sitevisit',
+            name='date',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+    ]

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.conf import settings
+from django.utils import timezone
 from recipes.models import Recipe
 
 
@@ -22,3 +23,51 @@ class RecipeViewLog(models.Model):
 
     def __str__(self):
         return f"{self.recipe} viewed by {self.user} on {self.timestamp}"
+
+
+class RecipeCardVisit(models.Model):
+    """Unique visits to the recipe cards API."""
+
+    PERIOD_HOUR = "hour"
+    PERIOD_DAY = "day"
+
+    PERIOD_CHOICES = [
+        (PERIOD_HOUR, "Hour"),
+        (PERIOD_DAY, "Day"),
+    ]
+
+    ip_address = models.GenericIPAddressField()
+    user_agent = models.CharField(max_length=256)
+    period_start = models.DateTimeField()
+    period_type = models.CharField(max_length=4, choices=PERIOD_CHOICES)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("ip_address", "user_agent", "period_start", "period_type")
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.ip_address} {self.period_type} @ {self.period_start}"
+
+
+def record_recipe_card_visit(request) -> None:
+    """Log a visit to the recipe cards API respecting uniqueness constraints."""
+
+    ip = request.META.get("REMOTE_ADDR", "")
+    ua = request.META.get("HTTP_USER_AGENT", "")[:255]
+    now = timezone.now()
+    hour_start = now.replace(minute=0, second=0, microsecond=0)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    RecipeCardVisit.objects.get_or_create(
+        ip_address=ip,
+        user_agent=ua,
+        period_start=hour_start,
+        period_type=RecipeCardVisit.PERIOD_HOUR,
+    )
+
+    RecipeCardVisit.objects.get_or_create(
+        ip_address=ip,
+        user_agent=ua,
+        period_start=day_start,
+        period_type=RecipeCardVisit.PERIOD_DAY,
+    )

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -25,6 +25,19 @@ class RecipeViewLog(models.Model):
         return f"{self.recipe} viewed by {self.user} on {self.timestamp}"
 
 
+class SiteVisit(models.Model):
+    """Generic site visit log."""
+
+    date = models.DateTimeField(auto_now_add=True)
+    ip_address = models.GenericIPAddressField()
+
+    class Meta:
+        ordering = ["-date"]
+
+    def __str__(self):  # pragma: no cover - simple representation
+        return f"{self.ip_address} @ {self.date}"
+
+
 class RecipeCardVisit(models.Model):
     """Unique visits to the recipe cards API."""
 

--- a/analytics/static/analytics/css/statistics.css
+++ b/analytics/static/analytics/css/statistics.css
@@ -8,7 +8,10 @@
 #verifyChart,
 #verifySubsChart,
 #viewsDayChart,
-#newRecipeChart {
+#newRecipeChart,
+#rcVisits24h,
+#rcVisits7d,
+#rcVisits30d {
   max-height: 300px;
 }
 

--- a/analytics/static/analytics/js/statistics.js
+++ b/analytics/static/analytics/js/statistics.js
@@ -108,6 +108,49 @@
       options: {responsive: true, maintainAspectRatio: false}
     });
 
+    const v24Ctx = document.getElementById('rcVisits24h').getContext('2d');
+    new Chart(v24Ctx, {
+      type: 'line',
+      data: {
+        labels: data.recipe_card_visits_24h.map(v => v.period_start),
+        datasets: [{
+          label: 'Unique visitors',
+          data: data.recipe_card_visits_24h.map(v => v.total),
+          borderColor: 'rgba(54,162,235,0.8)',
+          fill: false
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false, scales: {y: {beginAtZero: true}}}
+    });
+
+    const v7Ctx = document.getElementById('rcVisits7d').getContext('2d');
+    new Chart(v7Ctx, {
+      type: 'bar',
+      data: {
+        labels: data.recipe_card_visits_7d.map(v => v.period_start),
+        datasets: [{
+          label: 'Unique visitors',
+          data: data.recipe_card_visits_7d.map(v => v.total),
+          backgroundColor: 'rgba(75,192,192,0.6)'
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false}
+    });
+
+    const v30Ctx = document.getElementById('rcVisits30d').getContext('2d');
+    new Chart(v30Ctx, {
+      type: 'bar',
+      data: {
+        labels: data.recipe_card_visits_30d.map(v => v.period_start),
+        datasets: [{
+          label: 'Unique visitors',
+          data: data.recipe_card_visits_30d.map(v => v.total),
+          backgroundColor: 'rgba(201,203,207,0.6)'
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false}
+    });
+
     document.getElementById('totalUsers').innerText =
       'Total users: ' + data.subscription_breakdown.total;
   }

--- a/analytics/templates/admin_statistics.html
+++ b/analytics/templates/admin_statistics.html
@@ -55,6 +55,30 @@
         </div>
       </div>
     </div>
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">Recipe Card Visits (Last 24 Hours)</div>
+        <div class="card-body">
+          <canvas id="rcVisits24h"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">Recipe Card Visits (Last 7 Days)</div>
+        <div class="card-body">
+          <canvas id="rcVisits7d"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">Recipe Card Visits (Last 30 Days)</div>
+        <div class="card-body">
+          <canvas id="rcVisits30d"></canvas>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="row mt-5 gy-4">

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 from django.db.models import Count
 from django.db.models.functions import TruncDate
+from datetime import datetime, timedelta
 from django.contrib.sessions.models import Session
 from django.http import JsonResponse, HttpResponse
 from django.db.models import Q
@@ -10,7 +11,7 @@ from weasyprint import HTML
 
 from recipes.models import Recipe
 from account.models import User, Subscription
-from .models import RecipeViewLog
+from .models import RecipeViewLog, RecipeCardVisit
 
 
 def statistics_data(request):
@@ -108,6 +109,33 @@ def statistics_data(request):
         .order_by('day')
     )
 
+    # --- Recipe card unique visits ---
+    hour_start = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=23)
+    card_24h = (
+        RecipeCardVisit.objects.filter(period_type=RecipeCardVisit.PERIOD_HOUR, period_start__gte=hour_start)
+        .values('period_start')
+        .annotate(total=Count('id'))
+        .order_by('period_start')
+    )
+
+    day_start_7 = now.date() - timedelta(days=6)
+    day_start_dt_7 = timezone.make_aware(datetime.combine(day_start_7, datetime.min.time()))
+    card_7d = (
+        RecipeCardVisit.objects.filter(period_type=RecipeCardVisit.PERIOD_DAY, period_start__gte=day_start_dt_7)
+        .values('period_start')
+        .annotate(total=Count('id'))
+        .order_by('period_start')
+    )
+
+    day_start_30 = now.date() - timedelta(days=29)
+    day_start_dt_30 = timezone.make_aware(datetime.combine(day_start_30, datetime.min.time()))
+    card_30d = (
+        RecipeCardVisit.objects.filter(period_type=RecipeCardVisit.PERIOD_DAY, period_start__gte=day_start_dt_30)
+        .values('period_start')
+        .annotate(total=Count('id'))
+        .order_by('period_start')
+    )
+
     return JsonResponse({
         'views_per_recipe': list(views_per_recipe),
         'top_week': list(top_week),
@@ -116,6 +144,9 @@ def statistics_data(request):
         'active_sessions': active_sessions,
         'views_per_day': list(views_per_day),
         'new_recipes': list(new_recipes),
+        'recipe_card_visits_24h': list(card_24h),
+        'recipe_card_visits_7d': list(card_7d),
+        'recipe_card_visits_30d': list(card_30d),
         'subscription_breakdown': {
             'total': total_users,
             'premium': premium_users,

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -20,6 +20,7 @@ from .serializers import (
 from .translation_utils import get_requested_lang, SUPPORTED_LANGUAGES
 from .permissions import IsHealthySubscriber, IsPremiumSubscriber
 from account.models import Subscription
+from analytics.models import record_recipe_card_visit
 
 # Shared Swagger parameter for selecting response language
 LANG_PARAM = openapi.Parameter(
@@ -222,6 +223,7 @@ class RecipeCardViewSet(RecipeViewSet):
 
     @swagger_auto_schema(tags=['recipes'])
     def list(self, request, *args, **kwargs):
+        record_recipe_card_visit(request)
         return super().list(request, *args, **kwargs)
 
     @swagger_auto_schema(tags=['recipes'])


### PR DESCRIPTION
## Summary
- track unique visits per IP and user agent on the recipe card API
- expose new visit metrics via `statistics_data`
- show visits for the last 24h, 7 days and 30 days in the admin statistics page
- style and render new charts
- create migration for new model

## Testing
- `python manage.py makemigrations analytics` *(fails: ModuleNotFoundError: No module named 'django')*
- `python -m pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_688a85559038832b9b8b5b0dca7940f0