### PR TITLE
Add site visit analytics

### DIFF
--- a/analytics/admin.py
+++ b/analytics/admin.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from django.db.models import Count
 from django.core.paginator import Paginator
 
-from .models import RecipeViewLog
+from .models import RecipeViewLog, SiteVisit
 from recipes.models import Recipe
 from account.models import User
 from django.contrib.sessions.models import Session
@@ -17,6 +17,12 @@ class RecipeViewLogAdmin(admin.ModelAdmin):
     list_display = ('recipe', 'user', 'ip_address', 'country', 'timestamp')
     list_filter = ('country', 'recipe')
     search_fields = ('user__email', 'ip_address')
+
+
+@admin.register(SiteVisit)
+class SiteVisitAdmin(admin.ModelAdmin):
+    list_display = ('session_key', 'user', 'ip_address', 'timestamp')
+    search_fields = ('session_key', 'ip_address', 'user__email')
 
 
 def register_statistics(admin_site):

--- a/analytics/migrations/0002_sitevisit.py
+++ b/analytics/migrations/0002_sitevisit.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analytics', '0001_initial'),
+        ('account', '0006_remove_user_subscription_type'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteVisit',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('session_key', models.CharField(max_length=40, unique=True)),
+                ('timestamp', models.DateTimeField(auto_now_add=True)),
+                ('ip_address', models.GenericIPAddressField(blank=True, null=True)),
+                ('user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='site_visits', to='account.user')),
+            ],
+            options={'ordering': ['-timestamp']},
+        ),
+    ]

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -22,3 +22,23 @@ class RecipeViewLog(models.Model):
 
     def __str__(self):
         return f"{self.recipe} viewed by {self.user} on {self.timestamp}"
+
+
+class SiteVisit(models.Model):
+    """Stores a unique site visit identified by session key."""
+    session_key = models.CharField(max_length=40, unique=True)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="site_visits",
+    )
+    timestamp = models.DateTimeField(auto_now_add=True)
+    ip_address = models.GenericIPAddressField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["-timestamp"]
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return f"{self.session_key} at {self.timestamp}"

--- a/analytics/static/analytics/js/statistics.js
+++ b/analytics/static/analytics/js/statistics.js
@@ -108,6 +108,25 @@
       options: {responsive: true, maintainAspectRatio: false}
     });
 
+    const ctxVisit = document.getElementById('visitHourChart').getContext('2d');
+    new Chart(ctxVisit, {
+      type: 'line',
+      data: {
+        labels: data.visits_by_hour.map(v => v.hour),
+        datasets: [{
+          label: 'Unique visitors',
+          data: data.visits_by_hour.map(v => v.total),
+          borderColor: 'rgba(255,99,132,0.8)',
+          fill: false
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false, scales:{y:{beginAtZero:true}}}
+    });
+
+    document.getElementById('visits24h').innerText = data.visit_counts.last_24h;
+    document.getElementById('visits7d').innerText = data.visit_counts.last_7d;
+    document.getElementById('visits30d').innerText = data.visit_counts.last_30d;
+
     document.getElementById('totalUsers').innerText =
       'Total users: ' + data.subscription_breakdown.total;
   }

--- a/analytics/templates/admin_statistics.html
+++ b/analytics/templates/admin_statistics.html
@@ -55,6 +55,19 @@
         </div>
       </div>
     </div>
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">Site Visits Last 24 Hours</div>
+        <div class="card-body">
+          <canvas id="visitHourChart"></canvas>
+          <p class="mt-3">
+            24h: <span id="visits24h"></span>
+            | 7d: <span id="visits7d"></span>
+            | 30d: <span id="visits30d"></span>
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="row mt-5 gy-4">

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -1,0 +1,20 @@
+from .models import SiteVisit
+
+
+def log_site_visit(request):
+    """Record a unique visit based on the session key."""
+    session_key = request.session.session_key
+    if not session_key:
+        request.session.create()
+        session_key = request.session.session_key
+    if not SiteVisit.objects.filter(session_key=session_key).exists():
+        ip = request.META.get("HTTP_X_FORWARDED_FOR")
+        if ip:
+            ip = ip.split(",")[0].strip()
+        else:
+            ip = request.META.get("REMOTE_ADDR")
+        SiteVisit.objects.create(
+            session_key=session_key,
+            user=request.user if request.user.is_authenticated else None,
+            ip_address=ip,
+        )

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1,6 +1,6 @@
 from django.utils import timezone
 from django.db.models import Count
-from django.db.models.functions import TruncDate
+from django.db.models.functions import TruncDate, TruncHour
 from django.contrib.sessions.models import Session
 from django.http import JsonResponse, HttpResponse
 from django.db.models import Q
@@ -10,7 +10,7 @@ from weasyprint import HTML
 
 from recipes.models import Recipe
 from account.models import User, Subscription
-from .models import RecipeViewLog
+from .models import RecipeViewLog, SiteVisit
 
 
 def statistics_data(request):
@@ -108,6 +108,17 @@ def statistics_data(request):
         .order_by('day')
     )
 
+    visits_24h = SiteVisit.objects.filter(timestamp__gte=now - timezone.timedelta(hours=24)).count()
+    visits_7d = SiteVisit.objects.filter(timestamp__gte=now - timezone.timedelta(days=7)).count()
+    visits_30d = SiteVisit.objects.filter(timestamp__gte=now - timezone.timedelta(days=30)).count()
+    visits_by_hour = (
+        SiteVisit.objects.filter(timestamp__gte=now - timezone.timedelta(hours=24))
+        .annotate(hour=TruncHour('timestamp'))
+        .values('hour')
+        .annotate(total=Count('id'))
+        .order_by('hour')
+    )
+
     return JsonResponse({
         'views_per_recipe': list(views_per_recipe),
         'top_week': list(top_week),
@@ -116,6 +127,12 @@ def statistics_data(request):
         'active_sessions': active_sessions,
         'views_per_day': list(views_per_day),
         'new_recipes': list(new_recipes),
+        'visit_counts': {
+            'last_24h': visits_24h,
+            'last_7d': visits_7d,
+            'last_30d': visits_30d,
+        },
+        'visits_by_hour': list(visits_by_hour),
         'subscription_breakdown': {
             'total': total_users,
             'premium': premium_users,

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -17,6 +17,7 @@ from .serializers import (
     MealPlanSerializer, ShoppingListItemSerializer, CategorySerializer,
     MealTypeSerializer
 )
+from analytics.utils import log_site_visit
 from .translation_utils import get_requested_lang, SUPPORTED_LANGUAGES
 from .permissions import IsHealthySubscriber, IsPremiumSubscriber
 from account.models import Subscription
@@ -222,6 +223,7 @@ class RecipeCardViewSet(RecipeViewSet):
 
     @swagger_auto_schema(tags=['recipes'])
     def list(self, request, *args, **kwargs):
+        log_site_visit(request)
         return super().list(request, *args, **kwargs)
 
     @swagger_auto_schema(tags=['recipes'])


### PR DESCRIPTION
## Summary
- track site visits with new `SiteVisit` model
- log visits in `/api/recipe-cards/`
- expose visit statistics in analytics JSON
- show visit chart in admin statistics
- add admin for `SiteVisit`

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a96a175dc832bb55fc3d626e6ffce