### PR TITLE
Add site visit stats

### DIFF
--- a/analytics/admin.py
+++ b/analytics/admin.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from django.db.models import Count
 from django.core.paginator import Paginator
 
-from .models import RecipeViewLog
+from .models import RecipeViewLog, SiteVisit
 from recipes.models import Recipe
 from account.models import User
 from django.contrib.sessions.models import Session
@@ -17,6 +17,11 @@ class RecipeViewLogAdmin(admin.ModelAdmin):
     list_display = ('recipe', 'user', 'ip_address', 'country', 'timestamp')
     list_filter = ('country', 'recipe')
     search_fields = ('user__email', 'ip_address')
+
+
+@admin.register(SiteVisit)
+class SiteVisitAdmin(admin.ModelAdmin):
+    list_display = ('ip_address', 'timestamp')
 
 
 def register_statistics(admin_site):

--- a/analytics/migrations/0002_sitevisit.py
+++ b/analytics/migrations/0002_sitevisit.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analytics', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteVisit',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('timestamp', models.DateTimeField(auto_now_add=True)),
+                ('ip_address', models.GenericIPAddressField(blank=True, null=True)),
+            ],
+            options={'ordering': ['-timestamp']},
+        ),
+    ]

--- a/analytics/migrations/0003_sitevisit_session_key.py
+++ b/analytics/migrations/0003_sitevisit_session_key.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('analytics', '0002_sitevisit'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sitevisit',
+            name='session_key',
+            field=models.CharField(default='', max_length=40),
+            preserve_default=False,
+        ),
+    ]

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -22,3 +22,15 @@ class RecipeViewLog(models.Model):
 
     def __str__(self):
         return f"{self.recipe} viewed by {self.user} on {self.timestamp}"
+
+
+class SiteVisit(models.Model):
+    """Record each time the recipe cards API is accessed."""
+    timestamp = models.DateTimeField(auto_now_add=True)
+    ip_address = models.GenericIPAddressField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["-timestamp"]
+
+    def __str__(self):
+        return f"Visit from {self.ip_address} at {self.timestamp}"

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -28,6 +28,7 @@ class SiteVisit(models.Model):
     """Record each time the recipe cards API is accessed."""
     timestamp = models.DateTimeField(auto_now_add=True)
     ip_address = models.GenericIPAddressField(null=True, blank=True)
+    session_key = models.CharField(max_length=40)
 
     class Meta:
         ordering = ["-timestamp"]

--- a/analytics/static/analytics/css/statistics.css
+++ b/analytics/static/analytics/css/statistics.css
@@ -11,6 +11,11 @@
 #newRecipeChart {
   max-height: 300px;
 }
+#visitDayChart,
+#visitWeekChart,
+#visitMonthChart {
+  max-height: 300px;
+}
 
 .card {
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);

--- a/analytics/static/analytics/css/statistics.css
+++ b/analytics/static/analytics/css/statistics.css
@@ -11,10 +11,8 @@
 #newRecipeChart {
   max-height: 300px;
 }
-#visitDayChart,
-#visitWeekChart,
-#visitMonthChart {
-  max-height: 300px;
+#visitChart {
+  height: 300px;
 }
 
 .card {

--- a/analytics/static/analytics/js/statistics.js
+++ b/analytics/static/analytics/js/statistics.js
@@ -108,6 +108,48 @@
       options: {responsive: true, maintainAspectRatio: false}
     });
 
+    const visitDayCtx = document.getElementById('visitDayChart').getContext('2d');
+    new Chart(visitDayCtx, {
+      type: 'bar',
+      data: {
+        labels: ['24h'],
+        datasets: [{
+          label: 'Visits',
+          data: [data.site_visits.day],
+          backgroundColor: 'rgba(54,162,235,0.6)'
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false, scales: {y: {beginAtZero: true}}}
+    });
+
+    const visitWeekCtx = document.getElementById('visitWeekChart').getContext('2d');
+    new Chart(visitWeekCtx, {
+      type: 'bar',
+      data: {
+        labels: ['7d'],
+        datasets: [{
+          label: 'Visits',
+          data: [data.site_visits.week],
+          backgroundColor: 'rgba(75,192,192,0.6)'
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false, scales: {y: {beginAtZero: true}}}
+    });
+
+    const visitMonthCtx = document.getElementById('visitMonthChart').getContext('2d');
+    new Chart(visitMonthCtx, {
+      type: 'bar',
+      data: {
+        labels: ['30d'],
+        datasets: [{
+          label: 'Visits',
+          data: [data.site_visits.month],
+          backgroundColor: 'rgba(255,99,132,0.6)'
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false, scales: {y: {beginAtZero: true}}}
+    });
+
     document.getElementById('totalUsers').innerText =
       'Total users: ' + data.subscription_breakdown.total;
   }

--- a/analytics/static/analytics/js/statistics.js
+++ b/analytics/static/analytics/js/statistics.js
@@ -108,43 +108,19 @@
       options: {responsive: true, maintainAspectRatio: false}
     });
 
-    const visitDayCtx = document.getElementById('visitDayChart').getContext('2d');
-    new Chart(visitDayCtx, {
+    const visitCtx = document.getElementById('visitChart').getContext('2d');
+    new Chart(visitCtx, {
       type: 'bar',
       data: {
-        labels: ['24h'],
+        labels: ['24h', '7d', '30d'],
         datasets: [{
           label: 'Visits',
-          data: [data.site_visits.day],
-          backgroundColor: 'rgba(54,162,235,0.6)'
-        }]
-      },
-      options: {responsive: true, maintainAspectRatio: false, scales: {y: {beginAtZero: true}}}
-    });
-
-    const visitWeekCtx = document.getElementById('visitWeekChart').getContext('2d');
-    new Chart(visitWeekCtx, {
-      type: 'bar',
-      data: {
-        labels: ['7d'],
-        datasets: [{
-          label: 'Visits',
-          data: [data.site_visits.week],
-          backgroundColor: 'rgba(75,192,192,0.6)'
-        }]
-      },
-      options: {responsive: true, maintainAspectRatio: false, scales: {y: {beginAtZero: true}}}
-    });
-
-    const visitMonthCtx = document.getElementById('visitMonthChart').getContext('2d');
-    new Chart(visitMonthCtx, {
-      type: 'bar',
-      data: {
-        labels: ['30d'],
-        datasets: [{
-          label: 'Visits',
-          data: [data.site_visits.month],
-          backgroundColor: 'rgba(255,99,132,0.6)'
+          data: [data.site_visits.day, data.site_visits.week, data.site_visits.month],
+          backgroundColor: [
+            'rgba(54,162,235,0.6)',
+            'rgba(75,192,192,0.6)',
+            'rgba(255,99,132,0.6)'
+          ]
         }]
       },
       options: {responsive: true, maintainAspectRatio: false, scales: {y: {beginAtZero: true}}}

--- a/analytics/templates/admin_statistics.html
+++ b/analytics/templates/admin_statistics.html
@@ -57,6 +57,33 @@
     </div>
   </div>
 
+  <div class="row gy-4 mt-4">
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header">Visits Last 24 Hours</div>
+        <div class="card-body">
+          <canvas id="visitDayChart"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header">Visits Last 7 Days</div>
+        <div class="card-body">
+          <canvas id="visitWeekChart"></canvas>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card h-100">
+        <div class="card-header">Visits Last 30 Days</div>
+        <div class="card-body">
+          <canvas id="visitMonthChart"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="row mt-5 gy-4">
     <div class="col-lg-6">
       <h3>Most Viewed Recipes (7 days)</h3>

--- a/analytics/templates/admin_statistics.html
+++ b/analytics/templates/admin_statistics.html
@@ -58,27 +58,11 @@
   </div>
 
   <div class="row gy-4 mt-4">
-    <div class="col-md-4">
-      <div class="card h-100">
-        <div class="card-header">Visits Last 24 Hours</div>
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">Site Visits</div>
         <div class="card-body">
-          <canvas id="visitDayChart"></canvas>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="card h-100">
-        <div class="card-header">Visits Last 7 Days</div>
-        <div class="card-body">
-          <canvas id="visitWeekChart"></canvas>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-4">
-      <div class="card h-100">
-        <div class="card-header">Visits Last 30 Days</div>
-        <div class="card-body">
-          <canvas id="visitMonthChart"></canvas>
+          <canvas id="visitChart"></canvas>
         </div>
       </div>
     </div>

--- a/analytics/tests.py
+++ b/analytics/tests.py
@@ -1,0 +1,10 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from analytics.models import SiteVisit
+
+
+class SiteVisitTests(APITestCase):
+    def test_visit_logged_when_listing_cards(self):
+        url = reverse('recipecard-list')
+        self.client.get(url)
+        assert SiteVisit.objects.count() == 1

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -1,0 +1,15 @@
+from django.http import HttpRequest
+
+
+def get_client_ip(request: HttpRequest) -> str:
+    """Return the real client IP address.
+
+    Checks ``X-Forwarded-For`` first in case the app is behind a proxy.
+    """
+    xff = request.META.get('HTTP_X_FORWARDED_FOR')
+    if xff:
+        # X-Forwarded-For may contain multiple addresses, take the first
+        ip = xff.split(',')[0].strip()
+    else:
+        ip = request.META.get('REMOTE_ADDR')
+    return ip or ''

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -10,7 +10,7 @@ from weasyprint import HTML
 
 from recipes.models import Recipe
 from account.models import User, Subscription
-from .models import RecipeViewLog
+from .models import RecipeViewLog, SiteVisit
 
 
 def statistics_data(request):
@@ -18,6 +18,7 @@ def statistics_data(request):
     now = timezone.now()
     week_ago = now - timezone.timedelta(days=7)
     month_ago = now - timezone.timedelta(days=30)
+    day_ago = now - timezone.timedelta(days=1)
 
     views_per_recipe = (
         Recipe.objects.annotate(total=Count('view_logs'))
@@ -49,6 +50,10 @@ def statistics_data(request):
         .annotate(total=Count('id'))
         .order_by('day')
     )
+
+    visits_day = SiteVisit.objects.filter(timestamp__gte=day_ago).count()
+    visits_week = SiteVisit.objects.filter(timestamp__gte=week_ago).count()
+    visits_month = SiteVisit.objects.filter(timestamp__gte=month_ago).count()
 
     active_sessions = Session.objects.filter(expire_date__gte=now).count()
     total_users = User.objects.count()
@@ -116,6 +121,11 @@ def statistics_data(request):
         'active_sessions': active_sessions,
         'views_per_day': list(views_per_day),
         'new_recipes': list(new_recipes),
+        'site_visits': {
+            'day': visits_day,
+            'week': visits_week,
+            'month': visits_month,
+        },
         'subscription_breakdown': {
             'total': total_users,
             'premium': premium_users,

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -224,7 +224,12 @@ class RecipeCardViewSet(RecipeViewSet):
     def list(self, request, *args, **kwargs):
         from analytics.models import SiteVisit
         ip = request.META.get('REMOTE_ADDR')
-        SiteVisit.objects.create(ip_address=ip)
+        if not request.session.session_key:
+            request.session.save()
+        SiteVisit.objects.create(
+            ip_address=ip,
+            session_key=request.session.session_key,
+        )
         return super().list(request, *args, **kwargs)
 
     @swagger_auto_schema(tags=['recipes'])

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -222,6 +222,9 @@ class RecipeCardViewSet(RecipeViewSet):
 
     @swagger_auto_schema(tags=['recipes'])
     def list(self, request, *args, **kwargs):
+        from analytics.models import SiteVisit
+        ip = request.META.get('REMOTE_ADDR')
+        SiteVisit.objects.create(ip_address=ip)
         return super().list(request, *args, **kwargs)
 
     @swagger_auto_schema(tags=['recipes'])

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -223,11 +223,13 @@ class RecipeCardViewSet(RecipeViewSet):
     @swagger_auto_schema(tags=['recipes'])
     def list(self, request, *args, **kwargs):
         from analytics.models import SiteVisit
-        ip = request.META.get('REMOTE_ADDR')
+        from analytics.utils import get_client_ip
+
         if not request.session.session_key:
             request.session.save()
+
         SiteVisit.objects.create(
-            ip_address=ip,
+            ip_address=get_client_ip(request),
             session_key=request.session.session_key,
         )
         return super().list(request, *args, **kwargs)


### PR DESCRIPTION
## Summary
- add `SiteVisit` model and register in admin
- track visits on `RecipeCardViewSet.list`
- show 24h/7d/30d visit charts on statistics page
- handle new data in analytics views and JS
- style new charts

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a997057a0832baa2d9702d27d6ab8