### PR TITLE
Add custom meal field

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,50 @@ a user is logged in, recipes for their current subscription tier are included in
 the results. If the subscription has expired, the response again falls back to
 Standard recipes only.
 
+## Meal Plans
+
+Authenticated users can create meal plans via `/api/meal-plan/`. Provide the
+date, time and meal type by name. A recipe can be referenced with
+`recipe_id` or you may supply a short description with `custom_meal` when no
+recipe is selected:
+
+Default meal types (**breakfast**, **lunch**, **dinner**) are created by the
+database migrations. If you provide a new meal type name it will be added
+automatically.
+
+```json
+{
+  "date": "2025-07-31",
+  "time": "19:00",
+  "type": "dinner",
+  "recipe_id": null,
+  "custom_meal": "Grilled vegetables"
+}
+```
+
+To highlight days with scheduled meals, call `/api/meal-plan/planned-dates/`.
+It returns a list of dates that have any entries:
+
+```json
+{"planned_dates": ["2025-07-30", "2025-07-31"]}
+```
+
+To see plans for a specific day request `/api/meal-plan/date/<YYYY-MM-DD>/`:
+
+```json
+{
+  "date": "2025-07-31",
+  "meals": [
+    {
+      "type": "breakfast",
+      "time": "07:30",
+      "recipe": null,
+      "custom_meal": null
+    }
+  ]
+}
+```
+
 ## Admin Statistics
 
 The admin panel provides a `/admin/statistics/` page with charts and tables

--- a/account/views.py
+++ b/account/views.py
@@ -40,7 +40,12 @@ class CustomTokenRefreshView(TokenRefreshView):
 
     @swagger_auto_schema(tags=['Auth'])
     def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
+        serializer = self.get_serializer(data=request.data)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except User.DoesNotExist:
+            return Response({'detail': 'Invalid token'}, status=status.HTTP_401_UNAUTHORIZED)
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)
 
 class RegisterView(generics.CreateAPIView):
     serializer_class = RegisterSerializer

--- a/recipes/migrations/0010_mealplan_custom_meal.py
+++ b/recipes/migrations/0010_mealplan_custom_meal.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recipes', '0009_recipe_created_at'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mealplan',
+            name='custom_meal',
+            field=models.CharField(max_length=255, blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='mealplan',
+            name='recipe',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='recipes.recipe', null=True, blank=True),
+        ),
+    ]

--- a/recipes/migrations/0011_default_mealtypes.py
+++ b/recipes/migrations/0011_default_mealtypes.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def create_defaults(apps, schema_editor):
+    MealType = apps.get_model('recipes', 'MealType')
+    for name in ['breakfast', 'lunch', 'dinner']:
+        MealType.objects.get_or_create(name=name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recipes', '0010_mealplan_custom_meal'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_defaults, migrations.RunPython.noop),
+    ]

--- a/recipes/models.py
+++ b/recipes/models.py
@@ -103,8 +103,9 @@ class Instruction(models.Model):
 # --- MEAL PLAN ---
 class MealPlan(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='meal_plans')
-    recipe = models.ForeignKey(Recipe, on_delete=models.CASCADE)
+    recipe = models.ForeignKey(Recipe, on_delete=models.CASCADE, null=True, blank=True)
     meal_type = models.ForeignKey(MealType, on_delete=models.SET_NULL, null=True, related_name='meal_plans')
+    custom_meal = models.CharField(max_length=255, blank=True, null=True)
     scheduled_time = models.DateTimeField()
 
     def __str__(self):

--- a/recipes/serializers.py
+++ b/recipes/serializers.py
@@ -1,3 +1,4 @@
+import datetime
 from rest_framework import serializers
 from .models import (
     Category, MealType, Recipe,
@@ -175,26 +176,58 @@ class MealPlanSerializer(serializers.ModelSerializer):
     meal_type_id = serializers.PrimaryKeyRelatedField(
         queryset=MealType.objects.all(),
         source='meal_type',
-        write_only=True
+        write_only=True,
+        required=False
     )
+    type = serializers.CharField(write_only=True, required=False)
     recipe = RecipeSerializer(read_only=True)
     recipe_id = serializers.PrimaryKeyRelatedField(
         queryset=Recipe.objects.all(),
         source='recipe',
-        write_only=True
+        write_only=True,
+        required=False,
+        allow_null=True
     )
+    date = serializers.DateField(write_only=True)
+    time = serializers.TimeField(write_only=True)
+    custom_meal = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
     class Meta:
         model = MealPlan
         fields = [
             'id', 'user', 'recipe', 'recipe_id',
-            'meal_type', 'meal_type_id', 'scheduled_time'
+            'meal_type', 'meal_type_id', 'type',
+            'scheduled_time', 'date', 'time', 'custom_meal'
         ]
-        read_only_fields = ['user', 'recipe', 'meal_type']
+        read_only_fields = ['user', 'recipe', 'meal_type', 'scheduled_time']
 
     def create(self, validated_data):
         user = self.context['request'].user
-        return MealPlan.objects.create(user=user, **validated_data)
+        validated_data.pop('user', None)
+        meal_type_obj = validated_data.pop('meal_type', None)
+        meal_type_name = validated_data.pop('type', None)
+        if meal_type_name and not meal_type_obj:
+            meal_type_obj = MealType.objects.filter(
+                name__iexact=meal_type_name
+            ).first()
+            if not meal_type_obj:
+                meal_type_obj = MealType.objects.create(name=meal_type_name)
+        date = validated_data.pop('date')
+        time = validated_data.pop('time')
+        scheduled_time = datetime.datetime.combine(date, time)
+        return MealPlan.objects.create(
+            user=user,
+            meal_type=meal_type_obj,
+            scheduled_time=scheduled_time,
+            **validated_data
+        )
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data['date'] = instance.scheduled_time.date().isoformat()
+        data['time'] = instance.scheduled_time.time().strftime('%H:%M')
+        data['type'] = instance.meal_type.name if instance.meal_type else None
+        return data
 
 # SHOPPING LIST ITEM
 class ShoppingListItemSerializer(serializers.ModelSerializer):

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets, permissions, status, filters, generics
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+import datetime
 from django.db.models import Min, Q, F
 from django_filters.rest_framework import DjangoFilterBackend # type: ignore
 from drf_yasg.utils import swagger_auto_schema
@@ -20,6 +21,19 @@ from .serializers import (
 from .translation_utils import get_requested_lang, SUPPORTED_LANGUAGES
 from .permissions import IsHealthySubscriber, IsPremiumSubscriber
 from account.models import Subscription
+
+
+def get_recipes_for_user(user):
+    """Return recipes visible for the user's subscription plan."""
+    qs = Recipe.objects.all()
+    if not user or not user.is_authenticated:
+        return qs.filter(subscription_plan=Subscription.PLAN_STANDARD)
+    plan = user.current_plan
+    if plan == Subscription.PLAN_PREMIUM:
+        return qs
+    if plan == Subscription.PLAN_HEALTHY:
+        return qs.exclude(subscription_plan=Subscription.PLAN_PREMIUM)
+    return qs.filter(subscription_plan=Subscription.PLAN_STANDARD)
 
 # Shared Swagger parameter for selecting response language
 LANG_PARAM = openapi.Parameter(
@@ -278,7 +292,40 @@ class MealPlanViewSet(viewsets.ModelViewSet):
         return MealPlan.objects.filter(user=self.request.user)
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        serializer.save()
+
+    @action(detail=False, methods=['get'], url_path='planned-dates')
+    def planned_dates(self, request):
+        dates = (self.get_queryset()
+                 .values_list('scheduled_time', flat=True))
+        unique_dates = sorted({dt.date().isoformat() for dt in dates})
+        return Response({'planned_dates': unique_dates})
+
+    @action(detail=False, methods=['get'], url_path='date/(?P<date>[^/]+)')
+    def by_date(self, request, date=None):
+        """Return the meal plan for a given date."""
+        try:
+            day = datetime.datetime.strptime(date, '%Y-%m-%d').date()
+        except (TypeError, ValueError):
+            return Response({'error': 'Invalid date'}, status=status.HTTP_400_BAD_REQUEST)
+
+        meal_plans = (self.get_queryset()
+                       .filter(scheduled_time__date=day)
+                       .select_related('meal_type', 'recipe'))
+        plan_map = {mp.meal_type_id: mp for mp in meal_plans}
+
+        meals = []
+        for meal_type in MealType.objects.all():
+            mp = plan_map.get(meal_type.id)
+            meals.append({
+                'type': meal_type.name,
+                'time': mp.scheduled_time.time().strftime('%H:%M') if mp else None,
+                'recipe': ({'id': mp.recipe.id, 'title': mp.recipe.name}
+                           if mp and mp.recipe else None),
+                'custom_meal': mp.custom_meal if mp else None,
+            })
+
+        return Response({'date': day.isoformat(), 'meals': meals})
 
 # --- Shopping List CRUD (user-scoped) ---
 class ShoppingListItemViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
- allow MealPlan to store custom meals
- support date/time and meal type name on MealPlan serializer
- expose `/api/meal-plan/planned-dates/` endpoint
- document meal plan usage in README
- auto-create meal types as needed and seed defaults
- fix crash when creating meal plans
- add daily meal plan retrieval endpoint
- simplify daily plan output and validate token refresh

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688b6b167df8832bbcd0b1df7b7e6c96