### PR TITLE
Add query/tag options to recipe import and skip non-halal Spoonacular recipes

### DIFF
--- a/recipes/admin.py
+++ b/recipes/admin.py
@@ -109,11 +109,15 @@ class RecipeAdmin(admin.ModelAdmin):
             form = EdamamImportForm(request.POST)
             if form.is_valid():
                 count = form.cleaned_data["count"]
+                query = form.cleaned_data.get("query")
+                meal_type = form.cleaned_data.get("meal_type")
                 out = io.StringIO()
                 try:
                     call_command(
                         "add_edamam_recipes",
                         count,
+                        query=query,
+                        meal_type=meal_type,
                         stdout=out,
                         no_color=True,
                     )
@@ -155,11 +159,15 @@ class RecipeAdmin(admin.ModelAdmin):
             form = SpoonacularImportForm(request.POST)
             if form.is_valid():
                 count = form.cleaned_data["count"]
+                tags = form.cleaned_data.get("tags")
+                meal_type = form.cleaned_data.get("meal_type")
                 out = io.StringIO()
                 try:
                     call_command(
                         "fetch_spoonacular",
                         number=count,
+                        tags=tags,
+                        meal_type=meal_type,
                         stdout=out,
                         no_color=True,
                     )

--- a/recipes/forms.py
+++ b/recipes/forms.py
@@ -1,9 +1,37 @@
 from django import forms
 
 
+MEAL_CHOICES = [
+    ("breakfast", "Breakfast"),
+    ("lunch", "Lunch"),
+    ("dinner", "Dinner"),
+    ("random", "Random"),
+]
+
+
 class EdamamImportForm(forms.Form):
     count = forms.IntegerField(min_value=1, label="Number of recipes")
+    query = forms.CharField(
+        label="Ingredient or dish",
+        required=False,
+        help_text="Search term used when fetching recipes. Leave blank for random",
+    )
+    meal_type = forms.ChoiceField(
+        choices=MEAL_CHOICES,
+        label="Meal type",
+        initial="breakfast",
+    )
 
 
 class SpoonacularImportForm(forms.Form):
     count = forms.IntegerField(min_value=1, label="Number of recipes")
+    tags = forms.CharField(
+        label="Recipe tags",
+        required=False,
+        help_text="Comma separated tags like 'vegetarian,dessert'",
+    )
+    meal_type = forms.ChoiceField(
+        choices=MEAL_CHOICES,
+        label="Meal type",
+        initial="breakfast",
+    )

--- a/recipes/management/commands/add_edamam_recipes.py
+++ b/recipes/management/commands/add_edamam_recipes.py
@@ -333,8 +333,14 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--query",
-            default="egg",
-            help="Ingredient or dish to search for (default: egg)",
+            default=None,
+            help="Ingredient or dish to search for (leave blank for random)",
+        )
+        parser.add_argument(
+            "--meal-type",
+            choices=["breakfast", "lunch", "dinner", "random"],
+            dest="meal_type",
+            help="Meal type to search for",
         )
 
     def handle(self, *args, **options):
@@ -358,17 +364,21 @@ class Command(BaseCommand):
             )
 
         to_fetch = options["count"]
-        query = options["query"]
+        query = options.get("query")
+        meal_type = options.get("meal_type")
         fetched = 0
         while fetched < to_fetch:
             params = {
                 "type": "public",
-                "q": query,
                 "app_id": app_id,
                 "app_key": app_key,
                 "random": "true",
                 "health": ["pork-free", "alcohol-free"],
             }
+            if query:
+                params["q"] = query
+            if meal_type and meal_type != "random":
+                params["mealType"] = meal_type.title()
             try:
                 resp = requests.get(
                     "https://api.edamam.com/api/recipes/v2",
@@ -434,6 +444,11 @@ class Command(BaseCommand):
                     self.stderr.write(f"Skipping {title}: unable to download image")
                     continue
 
+                calories = _get_nutrient(recipe_data, "ENERC_KCAL", servings)
+                if not calories:
+                    self.stderr.write(f"Skipping {title}: missing calorie info")
+                    continue
+
                 recipe = Recipe.objects.create(
                     name=title,
                     description=description,
@@ -444,7 +459,7 @@ class Command(BaseCommand):
                         Recipe.PLAN_HEALTHY
                         if "Low-Fat" in recipe_data.get("healthLabels", [])
                         else Recipe.PLAN_STANDARD,
-                    calories=_get_nutrient(recipe_data, "ENERC_KCAL", servings) or 0,
+                    calories=calories,
                     protein=_get_nutrient(recipe_data, "PROCNT", servings),
                     fats=_get_nutrient(recipe_data, "FAT", servings),
                     carbs=_get_nutrient(recipe_data, "CHOCDF", servings),

--- a/recipes/management/commands/fetch_spoonacular.py
+++ b/recipes/management/commands/fetch_spoonacular.py
@@ -80,6 +80,36 @@ def _download_image(path, base_dir=None):
     filename = os.path.basename(file_path)
     return filename, ContentFile(data)
 
+NON_HALAL_KEYWORDS = {
+    "pork",
+    "bacon",
+    "ham",
+    "prosciutto",
+    "pepperoni",
+    "pancetta",
+    "lard",
+    "alcohol",
+    "wine",
+    "beer",
+    "rum",
+    "vodka",
+    "gin",
+    "whiskey",
+    "bourbon",
+    "brandy",
+    "tequila",
+    "cognac",
+    "liqueur",
+}
+
+
+def _contains_non_halal_ingredients(recipe_data):
+    for ing in recipe_data.get("extendedIngredients", []):
+        name = ing.get("name", "").lower()
+        if any(keyword in name for keyword in NON_HALAL_KEYWORDS):
+            return True
+    return False
+
 class Command(BaseCommand):
     help = "Fetch recipes from Spoonacular API and populate the database"
 
@@ -87,6 +117,18 @@ class Command(BaseCommand):
         parser.add_argument('--number', type=int, default=5,
                             help='Number of recipes to fetch from the API')
         parser.add_argument('--file', type=str, help='Path to a local JSON file with Spoonacular format data')
+        parser.add_argument(
+            '--tags',
+            type=str,
+            default=None,
+            help="Comma-separated tags to filter recipe types",
+        )
+        parser.add_argument(
+            '--meal-type',
+            choices=['breakfast', 'lunch', 'dinner', 'random'],
+            dest='meal_type',
+            help='Meal type to filter recipes',
+        )
 
     def handle(self, *args, **options):
         base_dir = None
@@ -106,6 +148,16 @@ class Command(BaseCommand):
                 'addRecipeInformation': True,
                 'addRecipeNutrition': True,
             }
+            tags = options.get('tags')
+            meal_type = options.get('meal_type')
+            if meal_type == 'random':
+                meal_type = None
+            if meal_type and tags:
+                params['tags'] = f"{tags},{meal_type}"
+            elif meal_type:
+                params['tags'] = meal_type
+            elif tags:
+                params['tags'] = tags
             self.stdout.write('Fetching recipes from Spoonacular...')
             response = requests.get(url, params=params)
             response.raise_for_status()
@@ -115,9 +167,21 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING('No recipes found in provided data'))
             return
         for r in recipes:
+            if _contains_non_halal_ingredients(r):
+                self.stderr.write(
+                    f"Skipping {r.get('title', 'No title')}: contains non-halal ingredients"
+                )
+                continue
+            calories = _get_nutrient(r, 'Calories', 'Energy', 'Energy (kcal)')
+            if not calories:
+                self.stderr.write(
+                    f"Skipping {r.get('title', 'No title')}: missing calorie info"
+                )
+                continue
+
             recipe = Recipe.objects.create(
                 name=r.get('title', 'No title'),
-                description=_short_description(r.get('summary')), 
+                description=_short_description(r.get('summary')),
                 prep_time=r.get('readyInMinutes') or 0,
                 cook_time=r.get('readyInMinutes') or 0,
                 servings=r.get('servings', 1),
@@ -125,7 +189,7 @@ class Command(BaseCommand):
                 subscription_plan=(
                     Recipe.PLAN_HEALTHY if r.get('veryHealthy', False) else Recipe.PLAN_STANDARD
                 ),
-                calories=_get_nutrient(r, 'Calories', 'Energy', 'Energy (kcal)') or 0,
+                calories=calories,
                 protein=_get_nutrient(r, 'Protein', 'Proteins'),
                 fats=_get_nutrient(r, 'Fat', 'Fats', 'Total Fat'),
                 carbs=_get_nutrient(r, 'Carbohydrates', 'Carbs', 'Carbohydrate'),


### PR DESCRIPTION
## Summary
- allow specifying an ingredient or dish when importing Edamam recipes
- support tags to limit Spoonacular recipe imports
- let admins choose a meal type (breakfast/lunch/dinner/random) for both Edamam and Spoonacular imports
- skip recipes without calorie information to prevent 0 kcal entries
- ignore Spoonacular recipes containing pork, alcohol or other non-halal ingredients

## Testing
- `pytest`
- `EMAIL_PORT=1025 EMAIL_HOST=localhost EMAIL_USE_TLS=false EMAIL_USE_SSL=false EMAIL_HOST_USER=foo EMAIL_HOST_PASSWORD=bar python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6890fed0514c832b82b3e9edde6c3246