### PR TITLE
Integrate Tahrirchi translation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,13 @@ endpoints to retrieve data in a specific language. The simplified
 curl '/api/recipes/?lang=uz'
 ```
 
-Translations are generated during import. If an `OPENAI_API_KEY` is provided,
-the OpenAI API is used for higher quality results. Otherwise the optional
-`googletrans` library is attempted, and if that fails a small built-in
-dictionary provides basic word-level translations.
+Translations are generated during import. When a `TAHRIRCHI_API_KEY` is set,
+requests are sent to [Tahrirchi](https://developer.tahrirchi.uz/) using its
+`translate-v2` API (the model can be chosen with `TAHRIRCHI_MODEL`, defaulting
+to `tilmoch`). If that service is not configured or the request fails, the
+system falls back to the OpenAI API when an `OPENAI_API_KEY` is supplied, then
+to the optional `googletrans` library, and finally to a small built-in
+dictionary for basic word-level translations.
 
 ### Pagination
 

--- a/recipes/translation_utils.py
+++ b/recipes/translation_utils.py
@@ -103,6 +103,52 @@ PHRASE_DICT: Dict[str, Dict[str, str]] = {
 }
 
 
+def _tahrirchi_translate(text: str, dest: str, src: str) -> str:
+    """Translate using Tahrirchi's ``translate-v2`` API if configured.
+
+    Expects ``TAHRIRCHI_API_KEY`` environment variable to be set. Optional
+    ``TAHRIRCHI_API_URL`` and ``TAHRIRCHI_MODEL`` environment variables can
+    override the default endpoint and model ("tilmoch" or "sayqalchi").
+    """
+    api_key = os.getenv("TAHRIRCHI_API_KEY")
+    if not api_key:
+        return ""
+
+    url = os.getenv(
+        "TAHRIRCHI_API_URL", "https://websocket.tahrirchi.uz/translate-v2"
+    )
+    model = os.getenv("TAHRIRCHI_MODEL", "tilmoch")
+
+    # Map our language codes to Tahrirchi's expectations
+    lang_map = {
+        "en": "eng_Latn",
+        "uz": "uzn_Latn",
+        "ru": "rus_Cyrl",
+    }
+    src_code = lang_map.get(src)
+    dest_code = lang_map.get(dest)
+    if not src_code or not dest_code:
+        return ""
+
+    try:  # pragma: no cover - network
+        resp = requests.post(
+            url,
+            json={
+                "text": text,
+                "source_lang": src_code,
+                "target_lang": dest_code,
+                "model": model,
+            },
+            headers={"Authorization": api_key, "Content-Type": "application/json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("translated_text", "")
+    except Exception:
+        return ""
+
+
 def _openai_translate(text: str, dest: str, src: str) -> str:
     """Translate using OpenAI if available and configured."""
     if not openai or not os.getenv("OPENAI_API_KEY"):
@@ -166,8 +212,9 @@ except Exception:  # If initialization fails, fall back to manual dictionary
 def translate_text(text: str, dest: str, src: str = 'en') -> str:
     """Translate text to the destination language.
 
-    Tries OpenAI's API first when configured, then googletrans, and finally
-    a small built-in dictionary as a last resort.
+    Tries the Tahrirchi API first when configured, then OpenAI, googletrans,
+    Google's web endpoint, and finally a small built-in dictionary as a
+    last resort.
     """
     if not text:
         return ''
@@ -176,6 +223,11 @@ def translate_text(text: str, dest: str, src: str = 'en') -> str:
         manual = _manual_translate(text, dest)
         if manual.lower() != text.lower():
             return manual
+
+    result = _tahrirchi_translate(text, dest, src)
+    if result:
+        return result
+
     result = _openai_translate(text, dest, src)
     if result:
         return result


### PR DESCRIPTION
## Summary
- add helper to translate via Tahrirchi API when TAHRIRCHI_API_KEY is set
- prefer Tahrirchi translations before existing fallbacks

## Testing
- `python -m py_compile recipes/translation_utils.py`
- `python manage.py test` *(fails: EMAIL_HOST not found)*
- `python manage.py fetch_spoonacular --number 5` *(fails: EMAIL_HOST not found)*
- `python manage.py add_edamam_recipes 10` *(fails: EMAIL_HOST not found)*

------
https://chatgpt.com/codex/tasks/task_e_689248102be0832bbe46754a75fd6185