### PR TITLE
Add language selection for meal plan and shopping list

### DIFF
--- a/recipes/serializers.py
+++ b/recipes/serializers.py
@@ -6,6 +6,7 @@ from .models import (
     MealPlan, ShoppingListItem,
     RecipeRating
 )
+from .translation_utils import translate_text
 
 # CATEGORY
 class CategorySerializer(serializers.ModelSerializer):
@@ -102,7 +103,9 @@ class RecipeSerializer(serializers.ModelSerializer):
         lang = self.context.get('lang')
         if lang and lang != 'en':
             for field in ['name', 'description']:
-                trans = getattr(instance, f'{field}_{lang}', '')
+                trans = getattr(instance, f'{field}_{lang}', '').strip()
+                if not trans:
+                    trans = translate_text(getattr(instance, field), lang)
                 if trans:
                     data[field] = trans
         return data
@@ -165,7 +168,9 @@ class RecipeCardSerializer(serializers.ModelSerializer):
         lang = self.context.get('lang')
         if lang and lang != 'en':
             for field in ['name', 'description']:
-                trans = getattr(instance, f'{field}_{lang}', '')
+                trans = getattr(instance, f'{field}_{lang}', '').strip()
+                if not trans:
+                    trans = translate_text(getattr(instance, field), lang)
                 if trans:
                     data[field] = trans
         return data

--- a/recipes/tests.py
+++ b/recipes/tests.py
@@ -2,7 +2,9 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import AccessToken
 from account.models import User, Subscription
-from recipes.models import Recipe, Ingredient, Instruction, ShoppingListItem
+from recipes.models import Recipe, Ingredient, Instruction, ShoppingListItem, MealPlan, MealType
+import datetime
+from django.utils import timezone
 
 class RecipeSubscriptionTests(APITestCase):
     def setUp(self):
@@ -270,7 +272,10 @@ class ShoppingListAddRecipeTests(APITestCase):
             subscription_plan=Subscription.PLAN_STANDARD,
         )
         Ingredient.objects.create(
-            recipe=self.recipe, name="very ripe banana", amount="1"
+            recipe=self.recipe,
+            name="very ripe banana",
+            name_uz="pishgan banan",
+            amount="1",
         )
 
         self.fraction_recipe = Recipe.objects.create(
@@ -341,4 +346,142 @@ class ShoppingListAddRecipeTests(APITestCase):
         assert res2.status_code == 200
         item.refresh_from_db()
         assert item.amount == "1"
+
+    def test_add_recipe_respects_language(self):
+        self.client.force_authenticate(self.user)
+        url = reverse("shoppinglist-add-recipe-ingredients") + "?lang=uz"
+        data = {"recipe_id": self.recipe.id}
+        res = self.client.post(url, data, format="json")
+        assert res.status_code == 200
+        assert ShoppingListItem.objects.filter(
+            user=self.user, name="pishgan banan"
+        ).exists()
+
+    def test_add_recipe_translates_when_missing_name(self):
+        self.client.force_authenticate(self.user)
+        recipe = Recipe.objects.create(
+            name="Chicken",
+            description="desc",
+            prep_time=1,
+            cook_time=1,
+            servings=1,
+            subscription_plan=Subscription.PLAN_STANDARD,
+        )
+        Ingredient.objects.create(recipe=recipe, name="onion", amount="1")
+        url = reverse("shoppinglist-add-recipe-ingredients") + "?lang=ru"
+        res = self.client.post(url, {"recipe_id": recipe.id}, format="json")
+        assert res.status_code == 200
+        assert ShoppingListItem.objects.filter(
+            user=self.user, name="лук"
+        ).exists()
+
+
+class MealPlanLanguageTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="planner@example.com",
+            first_name="Planner",
+            last_name="User",
+            password="StrongPass1",
+        )
+        Subscription.objects.create(user=self.user, plan=Subscription.PLAN_PREMIUM)
+        self.recipe = Recipe.objects.create(
+            name="Banana",
+            name_uz="Banan",
+            name_ru="Банан",
+            description="desc",
+            prep_time=1,
+            cook_time=1,
+            servings=1,
+            subscription_plan=Subscription.PLAN_STANDARD,
+        )
+        self.meal_type = MealType.objects.create(name="Breakfast")
+        MealPlan.objects.create(
+            user=self.user,
+            recipe=self.recipe,
+            meal_type=self.meal_type,
+            scheduled_time=timezone.make_aware(datetime.datetime(2024, 1, 1, 7, 30)),
+        )
+
+    def test_by_date_returns_translated_recipe_name(self):
+        self.client.force_authenticate(self.user)
+        url = reverse("mealplan-by-date", kwargs={"date": "2024-01-01"})
+        res = self.client.get(url + "?lang=uz")
+        assert res.status_code == 200
+        meal = next(m for m in res.data["meals"] if m["recipe"])
+        assert meal["recipe"]["name"] == "Banan"
+
+    def test_create_returns_translated_recipe_name(self):
+        self.client.force_authenticate(self.user)
+        url = reverse("mealplan-list") + "?lang=uz"
+        data = {
+            "date": "2025-08-15",
+            "type": "Breakfast",
+            "time": "19:00",
+            "recipe_id": self.recipe.id,
+            "custom_meal": None,
+        }
+        res = self.client.post(url, data, format="json")
+        assert res.status_code == 201
+        assert res.data["recipe"]["name"] == "Banan"
+
+    def test_create_with_ru_lang_returns_russian_name(self):
+        self.client.force_authenticate(self.user)
+        url = reverse("mealplan-list") + "?lang=ru"
+        data = {
+            "date": "2025-08-15",
+            "type": "Breakfast",
+            "time": "19:00",
+            "recipe_id": self.recipe.id,
+            "custom_meal": None,
+        }
+        res = self.client.post(url, data, format="json")
+        assert res.status_code == 201
+        assert res.data["recipe"]["name"] == "Банан"
+
+    def test_create_translates_when_missing_name(self):
+        self.client.force_authenticate(self.user)
+        recipe = Recipe.objects.create(
+            name="Chicken",
+            description="desc",
+            prep_time=1,
+            cook_time=1,
+            servings=1,
+            subscription_plan=Subscription.PLAN_STANDARD,
+        )
+        url = reverse("mealplan-list") + "?lang=ru"
+        data = {
+            "date": "2025-08-15",
+            "type": "Breakfast",
+            "time": "19:00",
+            "recipe_id": recipe.id,
+            "custom_meal": None,
+        }
+        res = self.client.post(url, data, format="json")
+        assert res.status_code == 201
+        assert res.data["recipe"]["name"] == "курица"
+
+    def test_by_date_translates_when_missing_name(self):
+        self.client.force_authenticate(self.user)
+        recipe = Recipe.objects.create(
+            name="Chicken",
+            description="desc",
+            prep_time=1,
+            cook_time=1,
+            servings=1,
+            subscription_plan=Subscription.PLAN_STANDARD,
+        )
+        MealPlan.objects.create(
+            user=self.user,
+            recipe=recipe,
+            meal_type=self.meal_type,
+            scheduled_time=timezone.make_aware(
+                datetime.datetime(2024, 1, 2, 7, 30)
+            ),
+        )
+        url = reverse("mealplan-by-date", kwargs={"date": "2024-01-02"})
+        res = self.client.get(url + "?lang=ru")
+        assert res.status_code == 200
+        meal = next(m for m in res.data["meals"] if m["recipe"] and m["recipe"]["id"] == recipe.id)
+        assert meal["recipe"]["name"] == "курица"
 

--- a/recipes/translation_utils.py
+++ b/recipes/translation_utils.py
@@ -23,10 +23,23 @@ LANG_NAMES = {
 }
 
 def get_requested_lang(request) -> str:
-    """Return a supported language code from the request query params."""
+    """Return a supported language code from query params, body or headers."""
     if not request:
         return 'en'
-    lang = request.query_params.get('lang', 'en')
+
+    lang = request.query_params.get('lang')
+
+    if not lang and hasattr(request, 'data'):
+        try:
+            lang = request.data.get('lang')
+        except Exception:  # pragma: no cover - non-dict data
+            lang = None
+
+    if not lang:
+        header = request.headers.get('Accept-Language', '')
+        if header:
+            lang = header.split(',')[0].split('-')[0]
+
     if lang not in SUPPORTED_LANGUAGES:
         return 'en'
     return lang

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -41,7 +41,7 @@ from .serializers import (
     MealPlanSerializer, ShoppingListItemSerializer, CategorySerializer,
     MealTypeSerializer
 )
-from .translation_utils import get_requested_lang, SUPPORTED_LANGUAGES
+from .translation_utils import get_requested_lang, SUPPORTED_LANGUAGES, translate_text
 from .permissions import IsHealthySubscriber, IsPremiumSubscriber
 from account.models import Subscription
 
@@ -302,13 +302,30 @@ class MealPlanViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save()
 
+    @swagger_auto_schema(manual_parameters=[LANG_PARAM])
+    def create(self, request, *args, **kwargs):
+        data = request.data.copy()
+        data.pop('lang', None)
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['lang'] = get_requested_lang(self.request)
+        return context
+
+    @swagger_auto_schema(manual_parameters=[LANG_PARAM])
     @action(detail=False, methods=['get'], url_path='planned-dates')
-    def planned_dates(self, request):
+    def planned_dates(self, request):  # pragma: no cover - simple aggregate
         dates = (self.get_queryset()
                  .values_list('scheduled_time', flat=True))
         unique_dates = sorted({dt.date().isoformat() for dt in dates})
         return Response({'planned_dates': unique_dates})
 
+    @swagger_auto_schema(manual_parameters=[LANG_PARAM])
     @action(detail=False, methods=['get'], url_path='date/(?P<date>[^/]+)')
     def by_date(self, request, date=None):
         """Return the meal plan for a given date."""
@@ -328,6 +345,8 @@ class MealPlanViewSet(viewsets.ModelViewSet):
             'dinner': '19:00',
         }
 
+        lang = get_requested_lang(request)
+        name_field = 'name' if lang == 'en' else f'name_{lang}'
         meals = []
         for meal_type in MealType.objects.all():
             mp = plan_map.get(meal_type.id)
@@ -335,13 +354,18 @@ class MealPlanViewSet(viewsets.ModelViewSet):
                 mp.scheduled_time.time().strftime('%H:%M')
                 if mp else default_times.get(meal_type.name.lower())
             )
+            recipe_data = None
+            if mp and mp.recipe:
+                name = getattr(mp.recipe, name_field, '').strip()
+                if not name and lang != 'en':
+                    name = translate_text(mp.recipe.name, lang)
+                if not name:
+                    name = mp.recipe.name
+                recipe_data = {'id': mp.recipe.id, 'name': name}
             meals.append({
                 'type': meal_type.name,
                 'time': time,
-                'recipe': (
-                    {'id': mp.recipe.id, 'title': mp.recipe.name}
-                    if mp and mp.recipe else None
-                ),
+                'recipe': recipe_data,
                 'custom_meal': mp.custom_meal if mp else None,
             })
 
@@ -367,6 +391,7 @@ class ShoppingListItemViewSet(viewsets.ModelViewSet):
             required=['recipe_id'],
             properties={'recipe_id': openapi.Schema(type=openapi.TYPE_INTEGER)}
         ),
+        manual_parameters=[LANG_PARAM],
         responses={200: 'Ingredients added'}
     )
     @action(detail=False, methods=['post'], url_path='add-recipe')
@@ -378,10 +403,17 @@ class ShoppingListItemViewSet(viewsets.ModelViewSet):
             recipe = Recipe.objects.get(id=recipe_id)
         except Recipe.DoesNotExist:
             return Response({'error': 'Recipe not found'}, status=status.HTTP_404_NOT_FOUND)
+        lang = get_requested_lang(request)
+        name_field = 'name' if lang == 'en' else f'name_{lang}'
         for ing in recipe.ingredients.all():
+            ing_name = getattr(ing, name_field, '').strip()
+            if not ing_name and lang != 'en':
+                ing_name = translate_text(ing.name, lang)
+            if not ing_name:
+                ing_name = ing.name
             item, created = ShoppingListItem.objects.get_or_create(
                 user=request.user,
-                name=ing.name,
+                name=ing_name,
                 unit=ing.unit or "",
                 defaults={'amount': ing.amount, 'checked': False}
             )


### PR DESCRIPTION
## Summary
- read language preference from query params, body, or Accept-Language header
- allow `lang` in meal plan creation body and return consistent recipe `name`
- test language handling for shopping list and meal plan endpoints
- add query-param tests covering Uzbek and Russian translations
- translate missing recipe and ingredient names on the fly
- document `lang` query parameter for meal plan creation

## Testing
- `EMAIL_HOST=localhost EMAIL_PORT=25 EMAIL_USE_TLS=False EMAIL_USE_SSL=False EMAIL_HOST_USER=user EMAIL_HOST_PASSWORD=pass DEFAULT_FROM_EMAIL=test@example.com python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689e035d9b88832bb130ec7e6e0c7cd3