### PR TITLE
Start Telegram bot alongside runserver

### DIFF
--- a/account/apps.py
+++ b/account/apps.py
@@ -1,3 +1,7 @@
+import os
+import sys
+from threading import Thread
+
 from django.apps import AppConfig
 
 class AccountConfig(AppConfig):
@@ -6,3 +10,7 @@ class AccountConfig(AppConfig):
 
     def ready(self):
         import account.signals  # noqa
+        if os.environ.get("RUN_MAIN") == "true" and "runserver" in sys.argv:
+            if os.getenv("TELEGRAM_BOT_TOKEN"):
+                from telegram_bot_example import main as run_bot
+                Thread(target=run_bot, daemon=True).start()

--- a/telegram_bot_example.py
+++ b/telegram_bot_example.py
@@ -9,9 +9,6 @@ from telegram.ext import Application, CommandHandler, ContextTypes
 WEBAPP_URL = os.getenv("WEBAPP_URL", "https://localhost:8000/telegram/recipes/")
 TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 
-if TOKEN is None:
-    raise RuntimeError("Set the TELEGRAM_BOT_TOKEN environment variable before running this script.")
-
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Respond to /start with a greeting and a WebApp button."""
     button = InlineKeyboardButton(
@@ -25,6 +22,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     )
 
 def main() -> None:
+    if TOKEN is None:
+        raise RuntimeError("Set the TELEGRAM_BOT_TOKEN environment variable before running this script.")
     application = Application.builder().token(TOKEN).build()
     application.add_handler(CommandHandler("start", start))
     application.run_polling()


### PR DESCRIPTION
## Summary
- launch Telegram bot in a background thread when `manage.py runserver` runs
- avoid import-time failure by checking `TELEGRAM_BOT_TOKEN` only in `main`

## Testing
- `EMAIL_HOST=localhost EMAIL_PORT=25 EMAIL_USE_TLS=False EMAIL_USE_SSL=False EMAIL_HOST_USER=user EMAIL_HOST_PASSWORD=pass DEFAULT_FROM_EMAIL=user python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a106103248832b885b65db693cdd88